### PR TITLE
Update alignment-editor-rcl

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "alignment-editor-rcl": "^0.2.4",
+    "alignment-editor-rcl": "^0.2.12",
     "deep-freeze": "^0.0.1",
     "gitea-react-toolkit": "^1.9.1",
     "js-yaml-parser": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,10 +2618,10 @@ ajv@^7.0.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-alignment-editor-rcl@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/alignment-editor-rcl/-/alignment-editor-rcl-0.2.4.tgz#f427b8751beafc0f7ca4defde19586fa367d8216"
-  integrity sha512-Ks3GP7GrnGjMPEz4Fv4K5UhV+r0wb4QzADR9UvWETd8iGW/XyZT54qlDRwQqRfY2fENyactuMlJEDdeX5oua7w==
+alignment-editor-rcl@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/alignment-editor-rcl/-/alignment-editor-rcl-0.2.12.tgz#c133ae6c07415a783aca7db923af44b24e2417bc"
+  integrity sha512-y3iQaf22UyiieiRtV2K3sBsqDqrSqw/B26AzjGgzb7xQM3h/uEcebXselxqlkKXFkoUfCGKgJeUhOqhYkKMhqw==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.32"
     "@fortawesome/free-solid-svg-icons" "^5.15.1"


### PR DESCRIPTION
Update to a new version of `alignment-editor-rcl` that has some defensive programming for nullish user inputs. With this new version, Titus 1:6 and 1:9 can be loaded without the editor crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-box3/anchor-alignment-poc/7)
<!-- Reviewable:end -->
